### PR TITLE
Changed second t.getLatitude() to t.getLongitude()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/CSVTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/CSVTrackExporter.java
@@ -97,7 +97,7 @@ public class CSVTrackExporter implements TrackExporter {
                 new Column("time", null),
                 new Column("trackpoint_type", t -> quote(t.getType().name())),
                 new Column("latitude", t -> t.hasLocation() ? COORDINATE_FORMAT.format(t.getLatitude()) : ""),
-                new Column("longitude", t -> t.hasLocation() ? COORDINATE_FORMAT.format(t.getLatitude()) : ""),
+                new Column("longitude", t -> t.hasLocation() ? COORDINATE_FORMAT.format(t.getLongitude()) : ""),
                 new Column("altitude", t -> t.hasAltitude() ? COORDINATE_FORMAT.format(t.getAltitude().toM()) : ""),
                 new Column("accuracy_horizontal", t -> t.hasHorizontalAccuracy() ? DISTANCE_FORMAT.format(t.getHorizontalAccuracy().toM()) : ""),
                 new Column("accuracy_vertical", t -> t.hasVerticalAccuracy() ? DISTANCE_FORMAT.format(t.getVerticalAccuracy().toM()) : ""),


### PR DESCRIPTION
I thought it was EXCEL or the csv-to-xlsx-converter, until I realized, the data is also broken in newly generated csv files.

**Describe the pull request**
Should fix csv exports, so they contain latitude AND longitude instead of latitude twice.

**Link to the the issue**
I've not looked in the issues, I just put "csv latitude" into the searchbar, found two files of this repo, looked at the one which has not "Test" in it's name, searched for "latitude" there and found three hits in two lines and changed one of them into a naming, that seems legit to me. I'm not a java-Dev and also not really into this project, I don't even know how to compile/run/test it.

**License agreement**
It's ok to put my contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
None